### PR TITLE
Add TTS wrapper settings and per-student speech composition

### DIFF
--- a/IslandCaller.Plugin2/Models/Settings.cs
+++ b/IslandCaller.Plugin2/Models/Settings.cs
@@ -43,6 +43,7 @@ namespace IslandCaller.Models
             RegistryKey IsC_ProfileKey = IsC_RootKey?.CreateSubKey("Profile", writable: true);
             RegistryKey IsC_HoverKey = IsC_RootKey?.CreateSubKey("Hover", writable: true);
             RegistryKey IsC_HoverKey_Position = IsC_HoverKey?.CreateSubKey("Position", writable: true);
+            RegistryKey IsC_TTSKey = IsC_RootKey?.CreateSubKey("TTS", writable: true);
 
             IsC_GeneralKey?.SetValue("BreakDisable", Instance.General.BreakDisable);
             IsC_GeneralKey?.SetValue("Interruptable", Instance.General.Interruptable);
@@ -55,6 +56,8 @@ namespace IslandCaller.Models
             IsC_HoverKey?.SetValue("ScalingFactor", Instance.Hover.ScalingFactor);
             IsC_HoverKey_Position?.SetValue("X", Instance.Hover.Position.X);
             IsC_HoverKey_Position?.SetValue("Y", Instance.Hover.Position.Y);
+            IsC_TTSKey?.SetValue("BeforeText", Instance.TTS.BeforeText);
+            IsC_TTSKey?.SetValue("AfterText", Instance.TTS.AfterText);
 
             ProfileService.CreateDemoProfile(Instance.Profile.DefaultProfile);
             ClassIsland.Core.Controls.CommonTaskDialogs.ShowDialog("Welcome", "欢迎使用IslandCaller2.0");
@@ -67,6 +70,7 @@ namespace IslandCaller.Models
             RegistryKey IsC_ProfileKey;
             RegistryKey IsC_HoverKey;
             RegistryKey IsC_HoverKey_Position;
+            RegistryKey IsC_TTSKey;
 
             if (IsC_RootKey == null)
             {
@@ -86,6 +90,7 @@ namespace IslandCaller.Models
                 IsC_ProfileKey = IsC_RootKey?.OpenSubKey("Profile", writable: true);
                 IsC_HoverKey = IsC_RootKey?.OpenSubKey("Hover", writable: true);
                 IsC_HoverKey_Position = IsC_HoverKey?.OpenSubKey("Position", writable: true);
+                IsC_TTSKey = IsC_RootKey?.OpenSubKey("TTS", writable: true) ?? IsC_RootKey?.CreateSubKey("TTS", writable: true);
 
                 Instance.General.BreakDisable = Convert.ToBoolean(IsC_GeneralKey?.GetValue("BreakDisable") ?? true);
                 Instance.General.Interruptable = Convert.ToBoolean(IsC_GeneralKey?.GetValue("Interruptable") ?? false);
@@ -98,6 +103,8 @@ namespace IslandCaller.Models
                 Instance.Hover.ScalingFactor = Convert.ToDouble(IsC_HoverKey?.GetValue("ScalingFactor") ?? 1.0);
                 Instance.Hover.Position.X = Convert.ToDouble(IsC_HoverKey_Position?.GetValue("X") ?? 200.0);
                 Instance.Hover.Position.Y = Convert.ToDouble(IsC_HoverKey_Position?.GetValue("Y") ?? 200.0);
+                Instance.TTS.BeforeText = IsC_TTSKey?.GetValue("BeforeText") as string ?? string.Empty;
+                Instance.TTS.AfterText = IsC_TTSKey?.GetValue("AfterText") as string ?? string.Empty;
                 Save();
             }
 
@@ -111,6 +118,7 @@ namespace IslandCaller.Models
             RegistryKey IsC_ProfileKey = IsC_RootKey?.OpenSubKey("Profile", writable: true);
             RegistryKey IsC_HoverKey = IsC_RootKey?.OpenSubKey("Hover", writable: true);
             RegistryKey IsC_HoverKey_Position = IsC_HoverKey?.OpenSubKey("Position", writable: true);
+            RegistryKey IsC_TTSKey = IsC_RootKey?.OpenSubKey("TTS", writable: true) ?? IsC_RootKey?.CreateSubKey("TTS", writable: true);
 
             IsC_GeneralKey?.SetValue("BreakDisable", Instance.General.BreakDisable);
             IsC_GeneralKey?.SetValue("Interruptable", Instance.General.Interruptable);
@@ -123,6 +131,8 @@ namespace IslandCaller.Models
             IsC_HoverKey?.SetValue("ScalingFactor", Instance.Hover.ScalingFactor);
             IsC_HoverKey_Position?.SetValue("X", Instance.Hover.Position.X);
             IsC_HoverKey_Position?.SetValue("Y", Instance.Hover.Position.Y);
+            IsC_TTSKey?.SetValue("BeforeText", Instance.TTS.BeforeText);
+            IsC_TTSKey?.SetValue("AfterText", Instance.TTS.AfterText);
         }
     }
     public static class SettingsBinder
@@ -135,6 +145,9 @@ namespace IslandCaller.Models
             // Hover
             model.Hover.PropertyChanged += (_, _) => onChange();
             model.Hover.Position.PropertyChanged += (_, _) => onChange();
+
+            // TTS
+            model.TTS.PropertyChanged += (_, _) => onChange();
         }
     }
 

--- a/IslandCaller.Plugin2/Models/SettingsModel.cs
+++ b/IslandCaller.Plugin2/Models/SettingsModel.cs
@@ -8,6 +8,7 @@ namespace IslandCaller.Models
         public GeneralSetting General { get; set; } = new GeneralSetting();
         public ProfileSetting Profile { get; set; } = new ProfileSetting();
         public HoverSetting Hover { get; set; } = new HoverSetting();
+        public TTSSetting TTS { get; set; } = new TTSSetting();
     }
 
     public class GeneralSetting : INotifyPropertyChanged
@@ -85,6 +86,33 @@ namespace IslandCaller.Models
             get => _profileprefer;
             set { if (_profileprefer != value) { _profileprefer = value; OnPropertyChanged(nameof(ProfilePrefer)); } }
         }
+        public event PropertyChangedEventHandler? PropertyChanged;
+        protected void OnPropertyChanged(string name) =>
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+
+    public class TTSSetting : INotifyPropertyChanged
+    {
+        public TTSSetting()
+        {
+            _beforeText = string.Empty;
+            _afterText = string.Empty;
+        }
+
+        private string _beforeText;
+        public string BeforeText
+        {
+            get => _beforeText;
+            set { if (_beforeText != value) { _beforeText = value; OnPropertyChanged(nameof(BeforeText)); } }
+        }
+
+        private string _afterText;
+        public string AfterText
+        {
+            get => _afterText;
+            set { if (_afterText != value) { _afterText = value; OnPropertyChanged(nameof(AfterText)); } }
+        }
+
         public event PropertyChangedEventHandler? PropertyChanged;
         protected void OnPropertyChanged(string name) =>
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));

--- a/IslandCaller.Plugin2/Services/IslandCallerNotificationProviderNew.cs
+++ b/IslandCaller.Plugin2/Services/IslandCallerNotificationProviderNew.cs
@@ -4,7 +4,6 @@ using ClassIsland.Core.Attributes;
 using ClassIsland.Core.Models.Notification;
 using ClassIsland.Shared.Enums;
 using IslandCaller.Models;
-using System.Text;
 
 namespace IslandCaller.Services.NotificationProvidersNew;
 
@@ -20,17 +19,16 @@ public class IslandCallerNotificationProviderNew(ILessonsService lessonsService,
 
     public async void RandomCall(int stunum)
     {
-        var sb = new StringBuilder();
+        List<string> students = new();
         for (int i = 0; i < stunum; i++)
         {
-            sb.Append(coreService.GetRandomStudent());
-
-            if (i != stunum-1)
-            {
-                sb.Append("  ");
-            }
+            students.Add(coreService.GetRandomStudent());
         }
-        string output = sb.ToString();
+
+        string output = string.Join("  ", students);
+        string speechContent = string.Join(
+            "  ",
+            students.Select(student => $"{Settings.Instance.TTS.BeforeText}{student}{Settings.Instance.TTS.AfterText}"));
         int maskduration = stunum * 2 + 1; // 计算持续时间
         Request = new NotificationRequest()
         {
@@ -38,7 +36,7 @@ public class IslandCallerNotificationProviderNew(ILessonsService lessonsService,
             {
                 x.Duration = new TimeSpan(0, 0, maskduration);
                 x.IsSpeechEnabled = true;
-                x.SpeechContent = output;
+                x.SpeechContent = speechContent;
             })
         };
         ShowNotification(Request);


### PR DESCRIPTION
### Motivation
- Provide configurable TTS prefix/suffix around student names so spoken notifications can include customizable before/after text and persist across runs.

### Description
- Add `TTSSetting` (implementing `INotifyPropertyChanged`) and a `TTS` property to `SettingsModel` with `BeforeText` and `AfterText` defaulting to `string.Empty` and raising `PropertyChanged` from setters.
- Persist TTS values to the registry by creating a `TTS` subkey in `InitializeNewInstall()`, loading `BeforeText`/`AfterText` in `Load()` (creating the subkey if missing), and saving them in `Save()`.
- Wire up autosave by subscribing to `model.TTS.PropertyChanged` in `SettingsBinder.Bind()`.
- Modify `RandomCall` in `IslandCallerNotificationProviderNew` to keep the visible `MaskContent` based on the original joined `output` while composing `SpeechContent` by wrapping each student name with `Settings.Instance.TTS.BeforeText` and `Settings.Instance.TTS.AfterText` and joining them, avoiding applying the wrappers only to the whole block.

### Testing
- Ran `git diff --check` as a static check which passed without reported issues.
- Attempted `dotnet --info && dotnet build` but the environment lacks the .NET SDK so build could not be executed (failure: `dotnet` not found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73f6b0bce4832b80c16e411594e775)